### PR TITLE
feat: add subset to homepage lists

### DIFF
--- a/src/content/communities.tsx
+++ b/src/content/communities.tsx
@@ -7,7 +7,7 @@ export const Communities: React.FC = () => {
   return (
     <section className={styles.section}>
       <div className={styles.communitiesHeading}>Communities</div>
-      <CategoryList name="communities" data={communities} />
+      <CategoryList name="communities" data={communities} limit={3} />
     </section>
   );
 };

--- a/src/content/consultants.tsx
+++ b/src/content/consultants.tsx
@@ -7,7 +7,7 @@ export const Consultants: React.FC = () => {
   return (
     <section className={styles.section}>
       <div className={styles.heading}>Consultants</div>
-      <CategoryList data={consultants} />
+      <CategoryList data={consultants} limit={5} />
     </section>
   );
 };

--- a/src/content/events.tsx
+++ b/src/content/events.tsx
@@ -12,7 +12,7 @@ export const Events: React.FC = () => {
   return (
     <section className={styles.section}>
       <div className={styles.heading}>Events</div>
-      <CategoryList name="events" data={ongoingEvents} />
+      <CategoryList name="events" data={ongoingEvents} limit={5} />
     </section>
   );
 };

--- a/src/content/frameworks.tsx
+++ b/src/content/frameworks.tsx
@@ -7,7 +7,7 @@ export const Frameworks: React.FC = () => {
   return (
     <section className={styles.section}>
       <div className={styles.heading}>Frameworks</div>
-      <CategoryList data={frameworks} />
+      <CategoryList data={frameworks} limit={5} />
     </section>
   );
 };

--- a/src/shared/category-list/category-list.tsx
+++ b/src/shared/category-list/category-list.tsx
@@ -14,6 +14,7 @@ import { Enterprise } from '@/data/resources/communities/enterprise';
 export interface CategoryListProps {
   name?: string; // category's name
   data; // TODO: combine types
+  limit?: number;
 }
 
 function dateFormatter(date: string): string {
@@ -61,11 +62,10 @@ const list = (id, title, src, startDate, description, link, identiconSeedMax) =>
   );
 };
 
-export const CategoryList: React.FC<CategoryListProps> = ({ name, data }) => {
+export const CategoryList: React.FC<CategoryListProps> = ({ name, data, limit }) => {
   const identiconSeedMax = (max: number) => Math.floor(Math.random() * max);
   const dataWithOngoingDates = data.filter(({ startDate, endDate }) => !isDatePast(startDate, endDate));
   let communities: (VentureCapital | GrantProgram | IncubatorAccelerator | Developer | Enterprise)[];
-
   if (name?.toLocaleLowerCase() === 'communities') {
     communities = data;
   }
@@ -79,25 +79,26 @@ export const CategoryList: React.FC<CategoryListProps> = ({ name, data }) => {
             <React.Fragment key={Object.keys(communityItem)[0]}>
               <div className={styles.communitySubHeaders}>{Object.keys(communityItem)}</div>{' '}
               <li className={styles.hr} />
-              {Object.values(communityItem)[0].map(
-                ({ id, title, src, startDate, description, link }, communityItemIndex) => (
+              {Object.values(communityItem)[0]
+                .slice(0, limit)
+                .map(({ id, title, src, startDate, description, link }, communityItemIndex) => (
                   <React.Fragment key={id}>
                     {list(id, title, src, startDate, description, link, identiconSeedMax)}
-                    {Object.values(communityItem)[0].length !== communityItemIndex + 1 ? (
+                    {Object.values(communityItem)[0].length !== communityItemIndex + 1 &&
+                    limit !== communityItemIndex + 1 ? (
                       <li className={styles.hr} />
                     ) : (
                       ''
                     )}
                   </React.Fragment>
-                )
-              )}
+                ))}
             </React.Fragment>
           ))
         ) : dataWithOngoingDates.length && name !== 'communities' ? (
-          data.map(({ id, title, src, startDate, description, link }, index: number) => (
+          data.slice(0, limit).map(({ id, title, src, startDate, description, link }, index: number) => (
             <React.Fragment key={id}>
               {list(id, title, src, startDate, description, link, identiconSeedMax)}
-              {data.length !== index + 1 ? <li className={styles.hr} /> : ''}
+              {data.length !== index + 1 && limit !== index + 1 ? <li className={styles.hr} /> : ''}
             </React.Fragment>
           ))
         ) : (

--- a/src/sidebar/accordion.tsx
+++ b/src/sidebar/accordion.tsx
@@ -6,7 +6,7 @@ import Link from '../link';
 export const Accordion: React.FC<any> = ({ title, content }) => {
   const [isActive, setIsActive] = useState(false);
   return (
-    <div className="accordion-item">
+    <div className={styles.accordionItem}>
       <button type="button" className={styles.accordionTitle} onClick={() => setIsActive(!isActive)}>
         <li className={styles.root}>
           <div className={styles.subNavHeading}>{title}</div>

--- a/src/sidebar/sidebar.module.css
+++ b/src/sidebar/sidebar.module.css
@@ -1,7 +1,6 @@
 .root {
   padding-left: 0;
   padding-right: 16px;
-  width: 100%;
   display: flex;
   position: relative;
   box-sizing: border-box;
@@ -37,7 +36,6 @@
   padding: 0;
   list-style: none;
   text-align: left;
-  width: 25%;
 }
 
 .subNavHeading {
@@ -51,10 +49,9 @@
   background-color: #d3dde5;
   border: none;
   height: 1px;
-  margin: 0;
   flex-shrink: 0;
   width: 140px;
-  margin: 0.5rem 0 0.625rem;
+  margin: 0.5rem 0 0.625rem 2rem;
   list-style: none;
 }
 
@@ -129,11 +126,13 @@
 
 .openChevron {
   fill: #f7f9fa;
+  padding-left: 2rem;
 }
 
 .chevron {
   fill: #f7f9fa;
   transform: scaleY(-1);
+  padding-left: 2rem;
 }
 
 .accordionTitle:hover > .root > div > .chevron {
@@ -148,6 +147,9 @@
   .root {
     padding-left: 1.5rem;
     font-size: 1rem;
+  }
+  .accordionItem {
+    width: 75%;
   }
   .nested {
     padding-left: 2rem;
@@ -193,5 +195,16 @@
 
   .accordionTitle {
     padding: 0;
+  }
+
+  .chevron, .openChevron {
+    padding-left: 0;
+  }
+}
+
+/* sm */
+@media only screen and (max-width: 960px) {
+  .accordionItem {
+    width: 100%;
   }
 }


### PR DESCRIPTION
# Overview

Add subset to homepage lists

# Screenshots for Mobile and Desktop views (if applicable)

![image](https://user-images.githubusercontent.com/20880360/138925469-fcea1360-e1a0-4f79-9aaf-e229353e7f29.png)

# Details

## General
- resolves sidebar style issues

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `npm run dev`
2. In browser, goto `localhost:3000`
3. Scroll down the homepage and verify a max of 3 per sub-section for community and a max of 5 for everything else
4. Navigate to communities, consultants, events, and frameworks to verify they are not limited
5. Get results :tada:
